### PR TITLE
Adds toprepos.py

### DIFF
--- a/crawler/toprepos.py
+++ b/crawler/toprepos.py
@@ -1,0 +1,11 @@
+import urllib.request
+import json
+
+res = urllib.request.urlopen(
+        "https://api.github.com/search/repositories?q=language:java&sort=stars&page=1&per_page=10&order=desc"
+)
+res = json.loads(res.read().decode('utf-8'))
+
+for item in res['items']:
+    print(item['full_name'])
+


### PR DESCRIPTION
Gets the 10 most popular (by # of stars) java repos on github. Simply pipe the output into crawler.py to obtain the java source files. Just make sure that the sources/ folder and path_index.txt are empty before doing so. 